### PR TITLE
Update joystick script comment

### DIFF
--- a/Joystick/joystick_to_serial.py
+++ b/Joystick/joystick_to_serial.py
@@ -42,7 +42,7 @@ pygame.joystick.init()
 joystick = pygame.joystick.Joystick(0)
 joystick.init()
 
-# Serial port — change to match your ESP32 COM port
+# Serial port (auto-detected above)
 ser = serial.Serial(port, 115200, timeout=0.1)
 time.sleep(2)  # wait for ESP32 reset
 


### PR DESCRIPTION
## Summary
- clarify that the serial port is auto-detected in `joystick_to_serial.py`

## Testing
- `python -m py_compile Battery\ Control/battery_display.py Joystick/joystick_to_serial.py`


------
https://chatgpt.com/codex/tasks/task_e_686836db6a008329b33544d7c1ef335a